### PR TITLE
Correction d’une faute de frappe dans le nom de Mme Arens

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Pourquoi l'Open data des décisions de justice ?
 
-   « ***La justice doit être accessible et la Cour de cassation s’engage à relever le défi en utilisant les potentialités des technologies  appliquées au droit*** » - *Chantal Arnes, première présidente de la Cour de cassation, pour La Semaine juridique - édition générale (30.03.20)*
+   « ***La justice doit être accessible et la Cour de cassation s’engage à relever le défi en utilisant les potentialités des technologies  appliquées au droit*** » - *Chantal Arens, première présidente de la Cour de cassation, pour La Semaine juridique - édition générale (30.03.20)*
 
 ### Qu'est l'ouverture des décisions de justice ?
 


### PR DESCRIPTION
Ce commit corrige une faute de frappe : au début du README, madame Chantal Ar**en**s _—saluée soit-elle—_ était appelée Ar**ne**s (le N et le E dans son nom de famille étaient inversés).

https://www.courdecassation.fr/les-membres-de-la-cour-historique/premiere-presidence/chantal-arens https://fr.wikipedia.org/wiki/Chantal_Arens